### PR TITLE
Adds support for midi-qol rolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This module is designed to capture your Players attacks and damage in an Encount
 
 This can then be viewed post battle to look upon for the Players to analyse and celebrate their attacks and as a DM, give you a better idea of how to build your Encounters in the future.
 
+The current module works on rolls from the following list. Future updates may include additional module support such as [DDB Gamelog](https://github.com/IamWarHead/ddb-game-log) and [Beyond20](https://foundryvtt.com/packages/beyond20/)
+
+**This module may not work if you have more than one enabled at a time. For example Better Rolls and midi-qol enabled at the same time**
+
+* [Better Rolls for 5e](https://github.com/RedReign/FoundryVTT-BetterRolls5e)
+* [midi-qol](https://gitlab.com/tposney/midi-qol)
+* Vanilla Foundry
+
+If you would like to see another module supported that isn't above then feel free to add it as a feature to the issues list in Github.
+
 [![Example](https://raw.githubusercontent.com/johnnolan/fvtt-encounter-stats/main/images/example.png)](https://raw.githubusercontent.com/johnnolan/fvtt-encounter-stats/main/images/example.png)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ Foundry modules page: [https://foundryvtt.com/packages/fvtt-encounter-stats](htt
 
 ## Dependencies
 
-This module heavily depends on the [midi-QoL](https://foundryvtt.com/packages/midi-qol/) module to attain the stats easily from their hook.
-
-* [midi-QoL](https://foundryvtt.com/packages/midi-qol/)
 * `dnd5e` game system (_Could work on others but haven't tested it_)
 
 ## Contact

--- a/scripts/FvttEncounterStats.js
+++ b/scripts/FvttEncounterStats.js
@@ -1,5 +1,10 @@
 import { CreateJournal } from "./Journal.js";
-import { AddCombatants, AddAttack5e, UpdateAttackBR5e } from "./DataParsing.js";
+import {
+  AddCombatants,
+  AddAttack5e,
+  UpdateAttackBR5e,
+  AddAttackMidiQol,
+} from "./DataParsing.js";
 import { GetStat, SaveStat, RemoveStat } from "./StatManager.js";
 
 async function _createCombat(data) {
@@ -51,6 +56,10 @@ export async function OnDeleteCombat() {
 
 export async function OnCreateChatMessage(attackData) {
   AddAttack5e(attackData);
+}
+
+export async function OnMidiRollComplete(workflow) {
+  AddAttackMidiQol(workflow);
 }
 
 export async function OnUpdateBetterRolls(attackData, isNew) {

--- a/scripts/Hooks.js
+++ b/scripts/Hooks.js
@@ -5,6 +5,7 @@ import {
   OnCreateChatMessage,
   OnUpdateCombat,
   OnUpdateBetterRolls,
+  OnMidiRollComplete,
 } from "./FvttEncounterStats.js";
 
 export async function SetupHooks() {
@@ -20,13 +21,20 @@ export async function SetupHooks() {
   window.Hooks.on("updateCombat", async function (arg1, arg2, arg3) {
     OnUpdateCombat(arg2.round);
   });
-  window.Hooks.on("createChatMessage", async function (data, options, user) {
-    OnCreateChatMessage(data);
-  });
-  window.Hooks.on("messageBetterRolls", async function (data, options, user) {
-    OnUpdateBetterRolls($(options.content), true);
-  });
-  window.Hooks.on("updateBetterRolls", async function (data, html, user) {
-    OnUpdateBetterRolls($(html), false);
-  });
+  if (game.modules.get("midi-qol")?.active) {
+    window.Hooks.on("midi-qol.RollComplete", async function (workflow) {
+      OnMidiRollComplete(workflow);
+    });
+  } else if (game.modules.get("betterrolls5e")?.active) {
+    window.Hooks.on("messageBetterRolls", async function (data, options, user) {
+      OnUpdateBetterRolls($(options.content), true);
+    });
+    window.Hooks.on("updateBetterRolls", async function (data, html, user) {
+      OnUpdateBetterRolls($(html), false);
+    });
+  } else {
+    window.Hooks.on("createChatMessage", async function (data, options, user) {
+      OnCreateChatMessage(data);
+    });
+  }
 }

--- a/scripts/Utils.js
+++ b/scripts/Utils.js
@@ -1,0 +1,11 @@
+export function IsValidAttack(attackType) {
+  const validTypes = ["mwak", "rwak", "msak", "rsak", "save"];
+
+  return validTypes.indexOf(attackType) > -1;
+}
+
+export function IsHealingSpell(attackType) {
+  const validTypes = ["heal"];
+
+  return validTypes.indexOf(attackType) > -1;
+}


### PR DESCRIPTION
midi-qol was not getting tracked correctly as reported in #31. This adds the following.

* Support for midi-qol auto rolls and seperate attack and damage rolls
* Prepares for categorising types of actions like heal, aoe, etc
* Sensibly checks for betterrolls5e, midi-qol or vanilla and adds the corresponding hook