### PR TITLE
Track HP changes and use Token image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # FVTT Encounter Stats
 
-This module is designed to capture your Players attacks and damage in an Encounter and store the results into a Journal Entry with a summary of their stats for each after you end the Encounter. 
+This module is designed to capture your Players attacks, damage and HP in an Encounter and store the results into a Journal Entry with a summary of their stats for each after you end the Encounter. 
 
 This can then be viewed post battle to look upon for the Players to analyse and celebrate their attacks and as a DM, give you a better idea of how to build your Encounters in the future.
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -13,6 +13,8 @@
     "FVTTEncounterStats.template.highest_damage_in_1_hit": "Highest Damage in 1 hit",
     "FVTTEncounterStats.template.enemies": "Enemies",
     "FVTTEncounterStats.template.hp": "HP",
+    "FVTTEncounterStats.template.startinghp": "Starting HP",
+    "FVTTEncounterStats.template.finalhp": "Final HP",
     "FVTTEncounterStats.template.ac": "AC",
     "FVTTEncounterStats.template.damage_total": "Damage Total",
     "FVTTEncounterStats.template.isCritical": "Critical",

--- a/languages/en.json
+++ b/languages/en.json
@@ -23,5 +23,9 @@
     "FVTTEncounterStats.template.weapon_spell_name": "Weapon/Spell Name",
     "FVTTEncounterStats.template.advantage": "Advantage",
     "FVTTEncounterStats.template.disadvantage": "Disadvantage",
-    "FVTTEncounterStats.template.attack_total": "Attack Total"
+    "FVTTEncounterStats.template.attack_total": "Attack Total",
+
+    "FVTTEncounterStats.template.attacks": "Attacks",
+    "FVTTEncounterStats.template.health": "Health",
+    "FVTTEncounterStats.template.rolltype": "Roll Type"
 }

--- a/scripts/ChatParsers.js
+++ b/scripts/ChatParsers.js
@@ -7,10 +7,46 @@ import {
   CombatantStats,
   _add,
 } from "./Utils.js";
-import { ATTACKTYPES } from "./Settings.js";
+import { GetStat, SaveStat } from "./StatManager.js";
+import { ATTACKTYPES, HEALTH_DATA_TEMPLATE } from "./Settings.js";
+
+export async function UpdateHealth(data) {
+  let stat = GetStat();
+  let healthData = duplicate(HEALTH_DATA_TEMPLATE);
+
+  let combatantStat = GetCombatantStats(stat, data.data._id);
+  if (!combatantStat) return;
+
+  healthData.round = stat.round;
+  healthData.actorId = data.data._id;
+  healthData.max = data.data.data.attributes.hp.max;
+  healthData.current = data.data.data.attributes.hp.value;
+
+  if (combatantStat.health.length > 0) {
+    healthData.previous =
+      combatantStat.health[combatantStat.health.length - 1].current;
+  } else {
+    healthData.previous = combatantStat.hp;
+  }
+
+  if (healthData.current > healthData.previous) {
+    healthData.diff = healthData.current - healthData.previous;
+    healthData.isheal = true;
+  } else if (healthData.current < healthData.previous) {
+    healthData.diff = healthData.previous - healthData.current;
+    healthData.isdamage = true;
+  }
+
+  if (healthData.diff > 0) {
+    combatantStat.health.push(healthData);
+  }
+
+  await SaveStat(stat);
+}
 
 export async function Default(stat, attackData, data) {
   let combatantStat = GetCombatantStats(stat, data.data.speaker.actor);
+  if (!combatantStat) return;
   attackData.actorId = data.data.speaker.actor;
 
   let chatType = await ChatType(data);
@@ -60,6 +96,7 @@ export async function Default(stat, attackData, data) {
 
 export async function MidiQol(stat, attackData, workflow) {
   let combatantStat = GetCombatantStats(stat, workflow.actor._id);
+  if (!combatantStat) return;
   attackData.id = workflow._id;
   attackData.actorId = workflow.actor._id;
 
@@ -98,6 +135,7 @@ export async function MidiQol(stat, attackData, workflow) {
 
 export async function BetterRollsFor5e(stat, attackData, $html, isNew) {
   let combatantStat = GetCombatantStats(stat, $html.attr("data-actor-id"));
+  if (!combatantStat) return;
   attackData.actorId = $html.attr("data-actor-id");
 
   if (!isNew) {

--- a/scripts/DataParsing.js
+++ b/scripts/DataParsing.js
@@ -41,6 +41,7 @@ export async function AddCombatants(combatants) {
     max: combatant.data.attributes.hp.max,
     ac: combatant.data.attributes.ac.value,
     events: [],
+    health: [],
     summaryList: {
       min: "0",
       max: "0",

--- a/scripts/DataParsing.js
+++ b/scripts/DataParsing.js
@@ -26,7 +26,7 @@ export async function AddAttack(data, type, isNew = false) {
   await SaveStat(stat);
 }
 
-export async function AddCombatants(combatants) {
+export async function AddCombatants(combatants, tokenImage) {
   const combatant = combatants.data;
   if (!_isValidCombatant(combatant.type)) return;
 
@@ -35,7 +35,7 @@ export async function AddCombatants(combatants) {
   const newCombatants = {
     name: combatant.name,
     id: combatant._id,
-    img: combatant.img,
+    img: tokenImage ? tokenImage : combatant.img,
     type: combatant.type,
     hp: combatant.data.attributes.hp.value,
     max: combatant.data.attributes.hp.max,

--- a/scripts/FvttEncounterStats.js
+++ b/scripts/FvttEncounterStats.js
@@ -26,7 +26,8 @@ async function _addCombatants(data) {
   const combatantsList = data.combat.data._source.combatants;
   for (let i = 0; i < combatantsList.length; i++) {
     const actorId = combatantsList[i].actorId;
-    AddCombatants(game.actors.get(actorId));
+    const tokenImage = canvas.tokens.get(combatantsList[i].tokenId)?.data?.img;
+    AddCombatants(game.actors.get(actorId), tokenImage);
   }
 }
 

--- a/scripts/FvttEncounterStats.js
+++ b/scripts/FvttEncounterStats.js
@@ -1,5 +1,6 @@
 import { CreateJournal } from "./Journal.js";
 import { AddCombatants, AddAttack } from "./DataParsing.js";
+import { UpdateHealth } from "./ChatParsers.js";
 import { ROLL_HOOK } from "./Settings.js";
 import { GetStat, SaveStat, RemoveStat } from "./StatManager.js";
 
@@ -51,17 +52,30 @@ export async function OnDeleteCombat() {
 }
 
 export async function OnCreateChatMessage(attackData) {
+  if (!_isInCombat) return;
   AddAttack(attackData, ROLL_HOOK.DEFAULT);
 }
 
 export async function OnMidiRollComplete(workflow) {
+  if (!_isInCombat) return;
   AddAttack(workflow, ROLL_HOOK.MIDI_QOL);
 }
 
 export async function OnUpdateBetterRolls(attackData, isNew) {
+  if (!_isInCombat) return;
   AddAttack(attackData, ROLL_HOOK.BETTERROLLS5E, isNew);
+}
+
+export async function OnUpdateHealth(data) {
+  if (!_isInCombat) return;
+  UpdateHealth(data);
 }
 
 export async function OnUpdateCombat(round) {
   _updateRound(round);
+}
+
+async function _isInCombat() {
+  let stat = GetStat();
+  return stat;
 }

--- a/scripts/Hooks.js
+++ b/scripts/Hooks.js
@@ -6,6 +6,7 @@ import {
   OnUpdateCombat,
   OnUpdateBetterRolls,
   OnMidiRollComplete,
+  OnUpdateHealth,
 } from "./FvttEncounterStats.js";
 
 export async function SetupHooks() {
@@ -20,6 +21,11 @@ export async function SetupHooks() {
   });
   window.Hooks.on("updateCombat", async function (arg1, arg2, arg3) {
     OnUpdateCombat(arg2.round);
+  });
+  window.Hooks.on("updateActor", async function (data, diff) {
+    if (diff.data?.attributes?.hp) {
+      OnUpdateHealth(data);
+    }
   });
   if (game.modules.get("midi-qol")?.active) {
     window.Hooks.on("midi-qol.RollComplete", async function (workflow) {

--- a/scripts/Settings.js
+++ b/scripts/Settings.js
@@ -33,3 +33,16 @@ export const ATTACK_DATA_TEMPLATE = {
     itemLink: null,
   },
 };
+
+export const HEALTH_DATA_TEMPLATE = {
+  id: null,
+  round: null,
+  tokenId: null,
+  actorId: null,
+  max: 0,
+  diff: 0,
+  previous: 0,
+  current: 0,
+  isdamage: false,
+  isheal: false,
+};

--- a/scripts/Template.js
+++ b/scripts/Template.js
@@ -77,7 +77,9 @@ function GenerateCombatant(combatant) {
               )}</div>
               <div class="fvtt-enc-stats_actor_stat-value">
                 <span>${
-                  combatant.health[combatant.health.length - 1].current
+                  combatant.health.length > 0
+                    ? combatant.health[combatant.health.length - 1].current
+                    : combatant.hp
                 }</span><span class="sep">/</span><span>${
     combatant.max
   }</span></div>

--- a/scripts/Template.js
+++ b/scripts/Template.js
@@ -114,42 +114,66 @@ function GenerateCombatant(combatant) {
           </div>
         </div>
       </header>
-      <section class="fvtt-enc-stats_combatants_attacks">
-        <div class="flexcol">
-          <ol class="items-list flexcol">
-            <li class="items-header flexrow">
-              <div class="item-name item-round">${game.i18n.format(
-                "FVTTEncounterStats.template.round"
-              )}</div>
-              <div class="item-name item-weapon">${game.i18n.format(
-                "FVTTEncounterStats.template.weapon_spell_name"
-              )}</div>
-              <div class="item-name">${game.i18n.format(
-                "FVTTEncounterStats.template.advantage"
-              )}</div>
-              <div class="item-name">${game.i18n.format(
-                "FVTTEncounterStats.template.disadvantage"
-              )}</div>
-              <div class="item-name">${game.i18n.format(
-                "FVTTEncounterStats.template.isCritical"
-              )}</div>
-              <div class="item-name">${game.i18n.format(
-                "FVTTEncounterStats.template.attack_total"
-              )}</div>
-              <div class="item-name">${game.i18n.format(
-                "FVTTEncounterStats.template.damage_total"
-              )}</div>
-            </li>
-            <ol class="item-list">
-              ${combatant.events
-                .map(function (event) {
-                  return GenerateAttackRow(event);
-                })
-                .join("")}
-                     
+      <section class="fvtt-enc-stats_combatants_data">
+        <section class="fvtt-enc-stats_combatants_health">
+          <div class="fvtt-enc-stats_title3">${game.i18n.format(
+            "FVTTEncounterStats.template.health"
+          )}</div>
+          <div class="flexcol">
+            <ol class="items-list flexcol">
+              <li class="items-header flexrow">
+                <div class="item-name item-round">${game.i18n.format(
+                  "FVTTEncounterStats.template.round"
+                )}</div>
+                <div class="item-name">${game.i18n.format(
+                  "FVTTEncounterStats.template.hp"
+                )}</div>
+              </li>
+              <ol class="item-list">
+                ${combatant.health
+                  .map(function (event) {
+                    return GenerateHealtRow(event);
+                  })
+                  .join("")}
+                      
+              </ol>
             </ol>
-          </ol>
-        </div>
+          </div>
+        </section>
+        <section class="fvtt-enc-stats_combatants_attacks">
+          <div class="fvtt-enc-stats_title3">${game.i18n.format(
+            "FVTTEncounterStats.template.attacks"
+          )}</div>
+          <div class="flexcol">
+            <ol class="items-list flexcol">
+              <li class="items-header flexrow">
+                <div class="item-name item-round">${game.i18n.format(
+                  "FVTTEncounterStats.template.round"
+                )}</div>
+                <div class="item-name item-weapon">${game.i18n.format(
+                  "FVTTEncounterStats.template.weapon_spell_name"
+                )}</div>
+                <div class="item-name">${game.i18n.format(
+                  "FVTTEncounterStats.template.rolltype"
+                )}</div>
+                <div class="item-name">${game.i18n.format(
+                  "FVTTEncounterStats.template.attack_total"
+                )}</div>
+                <div class="item-name">${game.i18n.format(
+                  "FVTTEncounterStats.template.damage_total"
+                )}</div>
+              </li>
+              <ol class="item-list">
+                ${combatant.events
+                  .map(function (event) {
+                    return GenerateAttackRow(event);
+                  })
+                  .join("")}
+                      
+              </ol>
+            </ol>
+          </div>
+        </section>
       </section>
     </div>
   </div>
@@ -165,11 +189,29 @@ function GenerateAttackRow(event) {
     <div class="item-name item-weapon">${
       event.item.itemLink ? event.item.itemLink : event.item.name
     }</div>
-    <div class="item-name">${event.advantage}</div>
-    <div class="item-name">${event.disadvantage}</div>
-    <div class="item-name">${event.isCritical}</div>
-    <div class="item-name">${event.attackTotal}</div>
+    <div class="item-name">${
+      event.advantage
+        ? "advantage"
+        : event.disadvantage
+        ? "disadvantage"
+        : "normal"
+    }</div>
+    <div class="item-name">${event.attackTotal} ${
+    event.isCritical ? " (c)" : ""
+  }</div>
     <div class="item-name">${event.damageTotal}</div>
+  </li>`;
+
+  return markup;
+}
+
+function GenerateHealtRow(event) {
+  let markup = `
+  <li class="item flexrow">
+    <div class="item-name item-round">${event.round}</div>
+    <div class="item-name">${event.current} (${event.isheal ? "+" : "-"}${
+    event.diff
+  })</div>
   </li>`;
 
   return markup;

--- a/scripts/Template.js
+++ b/scripts/Template.js
@@ -64,10 +64,21 @@ function GenerateCombatant(combatant) {
           <div class="fvtt-enc-stats_actor_statlist flexrow">
             <div class="fvtt-enc-stats_actor_stat">
               <div class="fvtt-enc-stats_actor_stat-key">${game.i18n.format(
-                "FVTTEncounterStats.template.hp"
+                "FVTTEncounterStats.template.startinghp"
               )}</div>
               <div class="fvtt-enc-stats_actor_stat-value">
                 <span>${combatant.hp}</span><span class="sep">/</span><span>${
+    combatant.max
+  }</span></div>
+            </div>
+            <div class="fvtt-enc-stats_actor_stat">
+              <div class="fvtt-enc-stats_actor_stat-key">${game.i18n.format(
+                "FVTTEncounterStats.template.finalhp"
+              )}</div>
+              <div class="fvtt-enc-stats_actor_stat-value">
+                <span>${
+                  combatant.health[combatant.health.length - 1].current
+                }</span><span class="sep">/</span><span>${
     combatant.max
   }</span></div>
             </div>

--- a/scripts/Utils.js
+++ b/scripts/Utils.js
@@ -65,6 +65,7 @@ export async function getIndex({ name = "" }) {
 }
 
 export function GetCombatantStats(stat, actorId) {
+  if (!stat?.combatants) return;
   return stat.combatants.find((f) => f.id === actorId);
 }
 

--- a/styles/module.css
+++ b/styles/module.css
@@ -71,6 +71,7 @@
   border-bottom: 1px solid #c9c7b8;
 }
 
+.fvtt-enc-stats_title3,
 .fvtt-enc-stats_actor_stat-value {
   font-weight: 400;
   font-size: 24px;
@@ -85,6 +86,20 @@
   padding: 0 5px;
 }
 
+.fvtt-enc-stats_combatants_data {
+  display: flex;
+}
+
+.fvtt-enc-stats_combatants_attacks {
+  flex: 3 0px;
+}
+.fvtt-enc-stats_combatants_health {
+  flex: 1 0px;
+}
+.fvtt-enc-stats_combatants_health {
+  max-width: 130px;
+}
+.fvtt-enc-stats_combatants_health,
 .fvtt-enc-stats_combatants_attacks {
   width: 100%;
   width: -moz-available;
@@ -93,11 +108,13 @@
   font-family: "Signika", sans-serif;
 }
 
+.fvtt-enc-stats_combatants_health .item-list,
 .fvtt-enc-stats_combatants_attacks .item-list {
   margin: 0;
   padding: 0;
 }
 
+.fvtt-enc-stats_combatants_health .item-name,
 .fvtt-enc-stats_combatants_attacks .item-name {
   margin: 2px 0;
   padding: 0;
@@ -105,6 +122,7 @@
   color: #191813;
 }
 
+.fvtt-enc-stats_combatants_health .items-header,
 .fvtt-enc-stats_combatants_attacks .items-header {
   height: 28px;
   margin: 2px 0;
@@ -115,6 +133,7 @@
   font-weight: bold;
 }
 
+.fvtt-enc-stats_combatants_health .items-header .item-name,
 .fvtt-enc-stats_combatants_attacks .items-header .item-name {
   font-size: 12px;
   color: #7a7971;
@@ -122,16 +141,24 @@
   border-right: 1px solid #c9c7b8;
 }
 
+.fvtt-enc-stats_combatants_health .items-header .item-round,
 .fvtt-enc-stats_combatants_attacks .items-header .item-round,
+.fvtt-enc-stats_combatants_health .items-list .item .item-round,
 .fvtt-enc-stats_combatants_attacks .items-list .item .item-round {
   flex: 0 0 40px;
 }
 
+.fvtt-enc-stats_combatants_health .items-header .item-weapon,
 .fvtt-enc-stats_combatants_attacks .items-header .item-weapon,
+.fvtt-enc-stats_combatants_health .items-list .item .item-weapon,
 .fvtt-enc-stats_combatants_attacks .items-list .item .item-weapon {
   flex: 0 0 200px;
 }
+.fvtt-enc-stats_combatants_attacks .items-list .item .item-weapon {
+  text-align: left;
+}
 
+.fvtt-enc-stats_combatants_health .items-list,
 .fvtt-enc-stats_combatants_attacks .items-list {
   list-style: none;
   margin: 0;

--- a/styles/module.css
+++ b/styles/module.css
@@ -71,6 +71,10 @@
   border-bottom: 1px solid #c9c7b8;
 }
 
+.fvtt-enc-stats_title3 {
+  font-family: "Modesto Condensed", "Palatino Linotype", serif;
+}
+
 .fvtt-enc-stats_title3,
 .fvtt-enc-stats_actor_stat-value {
   font-weight: 400;


### PR DESCRIPTION
Fixes #37 
Fixes #29 

Adds in a way to track HP changes. I am not happy with the layout but it works for now. New ticket incoming for design changes to the report.

Also fixes an issue where portrait images were out of proportion. Changes this to use the square token image instead of actor.