### PR TITLE
Fixes an issue with sending midi-qol workflow data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ This module is designed to capture your Players attacks, damage and HP in an Enc
 
 This can then be viewed post battle to look upon for the Players to analyse and celebrate their attacks and as a DM, give you a better idea of how to build your Encounters in the future.
 
-The current module works on rolls from the following list. Future updates may include additional module support such as [DDB Gamelog](https://github.com/IamWarHead/ddb-game-log) and [Beyond20](https://foundryvtt.com/packages/beyond20/)
+The current module works on rolls from the following list. Future updates may include additional module support such as [DDB Gamelog](https://github.com/IamWarHead/ddb-game-log)
 
 **This module may not work if you have more than one enabled at a time. For example Better Rolls and midi-qol enabled at the same time**
 
 * [Better Rolls for 5e](https://github.com/RedReign/FoundryVTT-BetterRolls5e)
+* [Beyond20](https://foundryvtt.com/packages/beyond20/)
 * [midi-qol](https://gitlab.com/tposney/midi-qol)
 * Vanilla Foundry
 

--- a/src/Hooks.js
+++ b/src/Hooks.js
@@ -29,6 +29,22 @@ function _setupSockerListeners() {
   });
 }
 
+function FormatMidiQol(workflow) {
+  const wf = {
+    _id: workflow._id,
+    actor: {
+      _id: workflow.actor._id,
+    },
+    item: {
+      _id: workflow.item._id,
+    },
+    attackRoll: workflow.attackRoll,
+    damageRoll: workflow.damageRoll,
+  };
+
+  return wf;
+}
+
 export async function SetupHooks() {
   if (game.user.isGM) {
     _setupSockerListeners();
@@ -52,7 +68,7 @@ export async function SetupHooks() {
     });
     if (game.modules.get("midi-qol")?.active) {
       window.Hooks.on("midi-qol.RollComplete", async function (workflow) {
-        OnMidiRollComplete(workflow);
+        OnMidiRollComplete(FormatMidiQol(workflow));
       });
     } else if (game.modules.get("betterrolls5e")?.active) {
       window.Hooks.on(
@@ -93,7 +109,7 @@ export async function SetupHooks() {
       window.Hooks.on("midi-qol.RollComplete", async function (workflow) {
         game.socket.emit(SOCKET_NAME, {
           event: "midi-qol.RollComplete",
-          data: workflow,
+          data: FormatMidiQol(workflow),
         });
       });
     } else if (game.modules.get("betterrolls5e")?.active) {


### PR DESCRIPTION
An error was occuring on the client preventing attacks from being recorded when sending the workflow object, this just send the required data needed instead of the whole object

Fixes #47