### PR TITLE
Improve compatibility for lancer-initiative.

### DIFF
--- a/scripts/DataParsing.js
+++ b/scripts/DataParsing.js
@@ -41,8 +41,8 @@ export async function AddAttack(data, type, isNew = false) {
 
 export async function AddCombatants(actor, tokenId) {
   const tokenImage = canvas.tokens.get(tokenId)?.data?.img;
-  const combatant = actor.data;
-  if (!_isValidCombatant(combatant.type)) return;
+  const combatant = actor?.data;
+  if (!_isValidCombatant(combatant?.type)) return;
 
   let stat = GetStat();
   if (!stat) return;


### PR DESCRIPTION
The actor and token properties on combatant are not always set, so
verify that an actor was passed before processing the combatant. This
improves compatibility with lancer-initiative, which uses a blank
combatant to represent no turn being active.
