### PR TITLE
Added missing template causing error

### DIFF
--- a/scripts/Settings.js
+++ b/scripts/Settings.js
@@ -53,3 +53,8 @@ export const HEALTH_DATA_TEMPLATE = {
   isdamage: false,
   isheal: false,
 };
+
+export const KILLED_DATA_TEMPLATE = {
+  round: null,
+  tokenName: null,
+};


### PR DESCRIPTION
A missing const causes the module to error on load, this adds it in to correctly load

Fixes #83